### PR TITLE
Allow Tracks to Have Multiple Groups and Subgroups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ oamlInternal.defs
 /AudioPluginOAML*
 /libAudioPluginOAML*
 /liboaml*
+/build/
 /build*/AudioPluginOAML*
 /build*/include
 /build*/libAudioPluginOAML*

--- a/include/oaml.h
+++ b/include/oaml.h
@@ -24,6 +24,7 @@
 #define __OAML_H__
 
 #include <stddef.h>
+#include <algorithm>
 
 //
 // Definitions
@@ -133,8 +134,8 @@ typedef struct {
 
 typedef struct {
 	std::string name;
-	std::string group;
-	std::string subgroup;
+	std::vector<std::string> groups;
+	std::vector<std::string> subgroups;
 	bool musicTrack;
 	bool sfxTrack;
 	int fadeIn;

--- a/include/oamlTrack.h
+++ b/include/oamlTrack.h
@@ -31,8 +31,8 @@ protected:
 	bool verbose;
 
 	std::string name;
-	std::string group;
-	std::string subgroup;
+	std::vector<std::string> groups;
+	std::vector<std::string> subgroups;
 
 	int lock;
 	int fadeIn;
@@ -55,8 +55,8 @@ public:
 	virtual ~oamlTrack();
 
 	void SetName(std::string trackName) { name = trackName; }
-	void SetGroup(std::string trackGroup) { group = trackGroup; }
-	void SetSubgroup(std::string trackSubgroup) { subgroup = trackSubgroup; }
+	void AddGroup(std::string trackGroup) { groups.push_back(trackGroup); }
+	void AddSubgroup(std::string trackSubgroup) { subgroups.push_back(trackSubgroup); }
 	void SetFadeIn(int trackFadeIn) { fadeIn = trackFadeIn; }
 	void SetFadeOut(int trackFadeOut) { fadeOut = trackFadeOut; }
 	void SetXFadeIn(int trackXFadeIn) { xfadeIn = trackXFadeIn; }
@@ -65,8 +65,10 @@ public:
 
 	const char *GetNameStr() const { return name.c_str(); }
 	std::string GetName() const { return name; }
-	std::string GetGroup() const { return group; }
-	std::string GetSubgroup() const { return subgroup; }
+	std::vector<std::string> GetGroups() const { return groups; }
+	std::vector<std::string> GetSubgroups() const { return subgroups; }
+	bool HasGroup(std::string trackGroup) const { return std::find(groups.begin(), groups.end(), trackGroup) != groups.end(); }
+	bool HasSubgroup(std::string trackSubgroup) const { return std::find(subgroups.begin(), subgroups.end(), trackSubgroup) != subgroups.end(); }
 	int GetFadeIn() const { return fadeIn; }
 	int GetFadeOut() const { return fadeOut; }
 	int GetXFadeIn() const { return xfadeIn; }

--- a/src/oamlBase.cpp
+++ b/src/oamlBase.cpp
@@ -117,8 +117,8 @@ oamlRC oamlBase::ReadDefs(const char *buf, int size) {
 		tinyxml2::XMLElement *trackEl = el->FirstChildElement();
 		while (trackEl != NULL) {
 			if (strcmp(trackEl->Name(), "name") == 0) track->SetName(trackEl->GetText());
-			else if (strcmp(trackEl->Name(), "group") == 0) track->SetGroup(trackEl->GetText());
-			else if (strcmp(trackEl->Name(), "subgroup") == 0) track->SetSubgroup(trackEl->GetText());
+			else if (strcmp(trackEl->Name(), "group") == 0) track->AddGroup(trackEl->GetText());
+			else if (strcmp(trackEl->Name(), "subgroup") == 0) track->AddSubgroup(trackEl->GetText());
 			else if (strcmp(trackEl->Name(), "fadeIn") == 0) track->SetFadeIn(strtol(trackEl->GetText(), NULL, 0));
 			else if (strcmp(trackEl->Name(), "fadeOut") == 0) track->SetFadeOut(strtol(trackEl->GetText(), NULL, 0));
 			else if (strcmp(trackEl->Name(), "xfadeIn") == 0) track->SetXFadeIn(strtol(trackEl->GetText(), NULL, 0));
@@ -190,8 +190,8 @@ oamlRC oamlBase::ReadDefs(const char *buf, int size) {
 		tinfo.name = track->GetName();
 		tinfo.musicTrack = track->IsMusicTrack();
 		tinfo.sfxTrack = track->IsSfxTrack();
-		tinfo.group = track->GetGroup();
-		tinfo.subgroup = track->GetSubgroup();
+		tinfo.groups = track->GetGroups();
+		tinfo.subgroups = track->GetSubgroups();
 		tinfo.fadeIn = track->GetFadeIn();
 		tinfo.fadeOut = track->GetFadeOut();
 		tinfo.xfadeIn = track->GetXFadeIn();
@@ -399,7 +399,7 @@ oamlRC oamlBase::PlayTrackByGroupRandom(const char *group) {
 	if (verbose) __oamlLog("%s %s\n", __FUNCTION__, group);
 
 	for (size_t i=0; i<musicTracks.size(); i++) {
-		if (musicTracks[i]->GetGroup().compare(group) == 0) {
+		if (musicTracks[i]->HasGroup(std::string(group))) {
 			list.push_back(i);
 		}
 	}
@@ -421,7 +421,7 @@ oamlRC oamlBase::PlayTrackByGroupAndSubgroupRandom(const char *group, const char
 	if (verbose) __oamlLog("%s %s %s\n", __FUNCTION__, group, subgroup);
 
 	for (size_t i=0; i<musicTracks.size(); i++) {
-		if (musicTracks[i]->GetGroup().compare(group) == 0 && musicTracks[i]->GetSubgroup().compare(subgroup) == 0) {
+		if (musicTracks[i]->HasGroup(std::string(group)) && musicTracks[i]->HasSubgroup(std::string(subgroup))) {
 			list.push_back(i);
 		}
 	}


### PR DESCRIPTION
This pull request makes it possible for tracks to have multiple groups and subgroups.

I found this very useful for Wyrmsun, as then I could designate some tracks as being used for multiple factions, and for both a faction and a civilization.
